### PR TITLE
Use SystemRegistry if available to watch for input event devices.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,16 @@
-# Elixir CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-elixir/ for more details
 version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.7
+      - image: circleci/elixir:1.7.3
     working_directory: ~/repo
+    environment:
+      - MIX_ENV: test
     steps:
       - checkout
       - run: sudo apt install qtwebengine5-dev qtmultimedia5-dev qt5-default -q
       - run: mix local.hex --force
-      - run: mix deps.get --only test
+      - run: mix deps.get
       - run: mix test
       - run: mix hex.build
       - run: mix docs

--- a/lib/webengine_kiosk/application.ex
+++ b/lib/webengine_kiosk/application.ex
@@ -1,0 +1,26 @@
+defmodule WebengineKiosk.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    opts = Application.get_all_env(:webengine_kiosk)
+
+    children =
+      if Code.ensure_loaded?(SystemRegistry) do
+        [
+          {WebengineKiosk.InputEvent, opts}
+        ]
+      else
+        []
+      end
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: WebengineKiosk.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/webengine_kiosk/input_event.ex
+++ b/lib/webengine_kiosk/input_event.ex
@@ -1,0 +1,89 @@
+if Code.ensure_loaded?(SystemRegistry) do
+  defmodule WebengineKiosk.InputEvent do
+    use GenServer
+
+    require Logger
+
+    @dev "/dev"
+    @group 1000
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    def init(opts) do
+      Application.ensure_all_started(:system_registry)
+      gid = opts[:gid] || @group
+      SystemRegistry.register()
+
+      {:ok,
+       %{
+         inputs: [],
+         gid: gid(gid)
+       }}
+    end
+
+    def handle_info(
+          {:system_registry, :global, %{state: %{"subsystems" => %{"input" => inputs}}}},
+          %{inputs: inputs} = state
+        ) do
+      {:noreply, state}
+    end
+
+    def handle_info(
+          {:system_registry, :global, %{state: %{"subsystems" => %{"input" => inputs}}} = reg},
+          state
+        ) do
+      inputs = Enum.reject(inputs, &(&1 in state.inputs))
+
+      {events, other_inputs} =
+        Enum.split_with(inputs, &String.starts_with?(List.last(&1), "event"))
+
+      new_events =
+        events
+        |> Enum.map(&{&1, get_in(reg, &1)})
+        |> Enum.reject(&is_nil(elem(&1, 1)))
+        |> Enum.map(&{elem(&1, 0), Map.get(elem(&1, 1), "devname")})
+        |> Enum.filter(&(chgrp(elem(&1, 1), state.gid) == :ok))
+        |> Enum.map(&elem(&1, 0))
+
+      inputs = new_events ++ other_inputs ++ state.inputs
+
+      {:noreply, %{state | inputs: inputs}}
+    end
+
+    def handle_info({:system_registry, _, _}, state) do
+      {:noreply, state}
+    end
+
+    defp chgrp(devname, gid) do
+      path = Path.join(@dev, devname)
+      Logger.info("webengine_kiosk: chgrp #{path}")
+      File.chgrp(path, gid)
+    end
+
+    defp gid(gid) when is_integer(gid), do: gid
+
+    defp gid(gid) when is_binary(gid) do
+      case File.read("/etc/group") do
+        {:ok, groups} ->
+          group_rec =
+            groups
+            |> String.split()
+            |> Enum.find(&String.starts_with?(&1, gid))
+
+          case group_rec do
+            nil ->
+              @group
+
+            group_rec ->
+              [_, _, gid | _] = String.split(group_rec, ":")
+              String.to_integer(gid)
+          end
+
+        _ ->
+          @group
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule WebengineKiosk.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {WebengineKiosk.Application, []}
     ]
   end
 
@@ -56,6 +57,7 @@ defmodule WebengineKiosk.MixProject do
 
   defp deps do
     [
+      {:system_registry, "~> 0.8", optional: true},
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -5,4 +5,5 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
+  "system_registry": {:hex, :system_registry, "0.8.0", "09240347628b001433d18279a2759ef7237ba7361239890d8c599cca9a2fbbc2", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This hooks into `system_registry` is available and monitors for input event devices to appear. Once they appear it changes the group to the specified `gid` in the `webengine_kiosk` config.