### PR TITLE
add event system + add QtWebChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It can also be linked into your application's supervision tree:
 # Example childspecs
 
    [
-      {WebengineKiosk, {[homepage: "https://somewhere.com", background: "black"], name: MyKiosk}}
+      {WebengineKiosk, {[homepage: "https://somewhere.com", background: "black"], name: Display}}
    ]
 
 # Somewhere else in your code
@@ -50,6 +50,51 @@ this, set one or more options:
 * `uid: uid` - run the browser as this user
 
 See `lib/webengine_kiosk.ex` for some untested options.
+
+## Events
+
+Process can subscribe to receive events from `WebengineKiosk`. Subscribe using `register` function like this from another process:
+
+```elixir
+WebengineKiosk.register(Display, self())
+```
+
+If the subscribing process is `GenServer` you can handle events like this:
+
+```elixir
+def handle_info({:webengine_kiosk, {:channel_message, message}}, state) do
+  # Do something with event ...
+  {:noreply, state}
+end
+```
+
+## Sending messages back to elixir
+
+You can send data from Javascript back to elixir using `QtWebChannel`.
+
+First you need to load appropriate javascript library:
+
+Place this somewhere in `<head>`
+```html
+<script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>
+```
+
+Than in your javascript code initialize `QtWebChannel`:
+
+```javascript
+new QWebChannel(qt.webChannelTransport, function (channel) {
+  var JSobject = channel.objects.elixirJsChannel;
+  window.elixirJsChannel = JSobject;
+});
+```
+
+than anywhere in your javascript code you can call following function to send messages:
+
+```javascript
+window.elixirJsChannel.send("Hello world!");
+```
+
+The message will appear as `:channel_message` event. Only text can be sent, but if you want so send objects, you can serialize the to JSON and send them as such.
 
 ## Installation
 

--- a/lib/webengine_kiosk/kiosk.ex
+++ b/lib/webengine_kiosk/kiosk.ex
@@ -1,0 +1,175 @@
+defmodule WebengineKiosk.Kiosk do
+  use GenServer
+  alias WebengineKiosk.{Message, Options}
+
+  require Logger
+
+  @moduledoc false
+
+  @spec start_link(%{args: Keyword.t(), parent: pid}, GenServer.options()) ::
+          {:ok, pid} | {:error, term}
+  def start_link(%{args: args, parent: parent}, genserver_opts \\ []) do
+    with :ok <- Options.check_args(args) do
+      GenServer.start_link(__MODULE__, %{args: args, parent: parent}, genserver_opts)
+    end
+  end
+
+  def init(%{args: args, parent: parent}) do
+    priv_dir = :code.priv_dir(:webengine_kiosk)
+    cmd = Path.join(priv_dir, "kiosk")
+
+    if !File.exists?(cmd) do
+      _ = Logger.error("Kiosk port application is missing. It should be at #{cmd}.")
+      raise "Kiosk port missing"
+    end
+
+    all_options = Options.add_defaults(args)
+
+    cmd_args =
+      all_options
+      |> Enum.flat_map(fn {key, value} -> ["--#{key}", to_string(value)] end)
+
+    set_permissions(all_options)
+    homepage = Keyword.get(all_options, :homepage)
+
+    port =
+      Port.open({:spawn_executable, cmd}, [
+        {:args, cmd_args},
+        {:cd, priv_dir},
+        {:packet, 2},
+        :use_stdio,
+        :binary,
+        :exit_status
+      ])
+
+    {:ok, %{port: port, homepage: homepage, parent: parent}}
+  end
+
+  def handle_call(:go_home, _from, state) do
+    send_port(state, Message.go_to_url(state.homepage))
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:go_to_url, url}, _from, state) do
+    send_port(state, Message.go_to_url(url))
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:run_javascript, code}, _from, state) do
+    send_port(state, Message.run_javascript(code))
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:blank, yes}, _from, state) do
+    send_port(state, Message.blank(yes))
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:reload, _from, state) do
+    send_port(state, Message.reload())
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:back, _from, state) do
+    send_port(state, Message.go_back())
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:forward, _from, state) do
+    send_port(state, Message.go_forward())
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:stop_loading, _from, state) do
+    send_port(state, Message.stop_loading())
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:set_zoom, factor}, _from, state) do
+    send_port(state, Message.set_zoom(factor))
+    {:reply, :ok, state}
+  end
+
+  def handle_info({_, {:data, raw_message}}, state) do
+    raw_message
+    |> Message.decode()
+    |> handle_browser_message(state)
+  end
+
+  def handle_info({port, {:exit_status, 0}}, %{port: port} = state) do
+    _ = Logger.info("webengine_kiosk: normal exit from port")
+    {:stop, :normal, state}
+  end
+
+  def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
+    _ = Logger.error("webengine_kiosk: unexpected exit from port: #{status}")
+    {:stop, :unexpected_exit, state}
+  end
+
+  defp handle_browser_message({:browser_crashed, reason, _exit_status}, state) do
+    _ =
+      Logger.error(
+        "webengine_kiosk: browser crashed: #{inspect(reason)}. Going home and hoping..."
+      )
+
+    send_event(state.parent, {:browser_crashed, reason})
+
+    # Try to recover by going back home
+    send_port(state, Message.go_to_url(state.homepage))
+    {:noreply, state}
+  end
+
+  defp handle_browser_message({:console_log, log}, state) do
+    _ = Logger.warn("webengine_kiosk(stderr): #{log}")
+    send_event(state.parent, {:console_log, log})
+    {:noreply, state}
+  end
+
+  defp handle_browser_message(message, state) do
+    _ = Logger.debug("webengine_kiosk: received #{inspect(message)}")
+    send_event(state.parent, message)
+    {:noreply, state}
+  end
+
+  defp send_event(parent, event) do
+    WebengineKiosk.dispatch_event(parent, event)
+  end
+
+  defp send_port(state, message) do
+    send(state.port, {self(), {:command, message}})
+  end
+
+  defp set_permissions(opts) do
+    # Check if we are on a raspberry pi
+    if File.exists?("/dev/vchiq") do
+      File.chgrp("/dev/vchiq", 28)
+      File.chmod("/dev/vchiq", 0o660)
+    end
+
+    if data_dir = Keyword.get(opts, :data_dir) do
+      File.mkdir_p(data_dir)
+
+      if uid = Keyword.get(opts, :uid) do
+        chown(data_dir, uid)
+      end
+    end
+  end
+
+  defp chown(file, uid) when is_binary(uid) do
+    case System.cmd("id", ["-u", uid]) do
+      {uid, 0} ->
+        uid =
+          String.trim(uid)
+          |> String.to_integer()
+
+        chown(file, uid)
+
+      _ ->
+        :error
+    end
+  end
+
+  defp chown(file, uid) when is_integer(uid) do
+    File.chown(file, uid)
+  end
+end

--- a/lib/webengine_kiosk/message.ex
+++ b/lib/webengine_kiosk/message.ex
@@ -15,6 +15,7 @@ defmodule WebengineKiosk.Message do
   @msg_set_zoom 13
   @msg_browser_crashed 14
   @msg_console_log 15
+  @msg_channel_msg 16
 
   @moduledoc false
 
@@ -55,6 +56,7 @@ defmodule WebengineKiosk.Message do
           | {:url_changed, String.t()}
           | {:browser_crashed, atom(), byte()}
           | {:console_log, String.t()}
+          | {:channel_message, String.t()}
   def decode(<<@msg_progress, value>>), do: {:progress, value}
   def decode(<<@msg_url_changed, url::binary>>), do: {:url_changed, url}
   def decode(<<@msg_loading_page>>), do: :started_loading_page
@@ -67,6 +69,10 @@ defmodule WebengineKiosk.Message do
 
   def decode(<<@msg_console_log, message::binary>>) do
     {:console_log, message}
+  end
+
+  def decode(<<@msg_channel_msg, message::binary>>) do
+    {:channel_message, message}
   end
 
   def decode(<<msg_type, _payload::binary>>), do: {:unknown, msg_type}

--- a/src/ElixirJsChannel.cpp
+++ b/src/ElixirJsChannel.cpp
@@ -1,0 +1,6 @@
+#include "ElixirJsChannel.h"
+
+void ElixirJsChannel::send(const QString &messageStr)
+{
+    emit received(messageStr);
+}

--- a/src/ElixirJsChannel.h
+++ b/src/ElixirJsChannel.h
@@ -1,0 +1,18 @@
+#ifndef ELIXIRJSCHANNEL_H
+#define ELIXIRJSCHANNEL_H
+
+#include <QObject>
+
+class ElixirJsChannel : public QObject
+{
+public:
+    Q_OBJECT
+
+signals:
+    void received(const QString &messageStr);
+
+public slots:
+    void send(const QString &messageStr);
+};
+
+#endif // ELIXIRJSCHANNEL_H

--- a/src/Kiosk.h
+++ b/src/Kiosk.h
@@ -2,6 +2,7 @@
 #define KIOSK_H
 
 #include "KioskSettings.h"
+#include "ElixirJsChannel.h"
 #include <QWebEnginePage>
 
 class ElixirComs;
@@ -39,6 +40,7 @@ private slots:
     void startLoading();
     void setProgress(int p);
     void finishLoading();
+    void elixirMessageReceived(const QString &messageStr);
 
     void handleWakeup();
     void handleRenderProcessTerminated(QWebEnginePage::RenderProcessTerminationStatus status, int exitCode);
@@ -48,6 +50,9 @@ private:
     QRect calculateWindowRect() const;
 
 private:
+    QWebChannel *webChannel_;
+    ElixirJsChannel *elixirChannel_;
+
     const KioskSettings *settings_;
     ElixirComs *coms_;
     StderrPipe *stderrPipe_;

--- a/src/KioskMessage.cpp
+++ b/src/KioskMessage.cpp
@@ -68,3 +68,9 @@ KioskMessage KioskMessage::consoleLog(const QByteArray &line)
     message.prepend(KioskMessage::ConsoleLog);
     return KioskMessage(message, message.length());
 }
+
+KioskMessage KioskMessage::channelMessage(const QString &message)
+{
+    QByteArray message_ba = message.toUtf8();
+    return KioskMessage(KioskMessage::ChannelMessage, message_ba);
+}

--- a/src/KioskMessage.h
+++ b/src/KioskMessage.h
@@ -23,7 +23,8 @@ public:
         StopLoading = 12,
         SetZoom = 13,
         BrowserCrashed = 14,
-        ConsoleLog = 15
+        ConsoleLog = 15,
+        ChannelMessage = 16
     };
 
     explicit KioskMessage(const QByteArray &rawMessage);
@@ -43,6 +44,7 @@ public:
     static KioskMessage wakeup();
     static KioskMessage browserCrashed(int terminationStatus, int exitCode);
     static KioskMessage consoleLog(const QByteArray &line);
+    static KioskMessage channelMessage(const QString &message);
 
 private:
     const QByteArray rawMessage_;

--- a/src/kiosk.pro
+++ b/src/kiosk.pro
@@ -7,6 +7,7 @@ TARGET = kiosk
 TEMPLATE = app
 
 SOURCES += main.cpp\
+    ElixirJsChannel.cpp \
     KioskSettings.cpp \
     ElixirComs.cpp \
     KioskView.cpp \
@@ -19,6 +20,7 @@ SOURCES += main.cpp\
     StderrPipe.cpp
 
 HEADERS  += \
+    ElixirJsChannel.h \
     KioskSettings.h \
     ElixirComs.h \
     KioskView.h \


### PR DESCRIPTION
This commit adds event system, where you can subscribe to browser events from external Elixir process.

Also it adds possibility to send messages through QtWebChannel back and use the event system to receive these messages from external Elixir process.

I needed to add one supervisor to decouple the event registry from the main GenServer. I tried to keep all the external API the same, that's why some places can look a bit weird.