### PR TITLE
Adds 2 new options: AcceptLanguage + UserAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ this, set one or more options:
 * `fullscreen: boolean` - show fullscreen
 * `gid: gid` - run the browser with this group id
 * `homepage: url` - load this page first. For local files, specify `file:///path/to/index.html`
+* `http_accept_language: string` - overrides the default Accept-Language string
+* `http_user_agent: string` - overrides the default UserAgent string
 * `monitor: index` - select the monitor for the web browser (0, 1, etc.)
 * `opengl: "gl" | "gles" | "software" | "auto"` - specify the OpenGL backend. This is only a hint.
 * `progress: boolean` - show a progress bar when loading pages

--- a/lib/webengine_kiosk.ex
+++ b/lib/webengine_kiosk.ex
@@ -31,6 +31,8 @@ defmodule WebengineKiosk do
   * `fullscreen: boolean` - show fullscreen
   * `gid: gid` - run the browser with this group id
   * `homepage: url` - load this page first. For local files, specify `file:///path/to/index.html`
+  * `http_accept_language: string` - overrides the default Accept-Language string
+  * `http_user_agent: string` - overrides the default UserAgent string
   * `monitor: index` - select the monitor for the web browser (0, 1, etc.)
   * `opengl: "gl" | "gles" | "software" | "auto"` - specify the OpenGL backend. This is only a hint.
   * `progress: boolean` - show a progress bar when loading pages

--- a/lib/webengine_kiosk/options.ex
+++ b/lib/webengine_kiosk/options.ex
@@ -27,7 +27,9 @@ defmodule WebengineKiosk.Options do
     :gid,
     :blank_image,
     :background_color,
-    :run_as_root
+    :run_as_root,
+    :http_accept_language,
+    :http_user_agent
   ]
 
   @moduledoc false

--- a/src/KioskSettings.cpp
+++ b/src/KioskSettings.cpp
@@ -44,7 +44,9 @@ KioskSettings::KioskSettings(const QCoreApplication &app)
             {"zoom_factor", "The zoom factor for the page (0.25 to 5.0).", "factor", "1.0"},
             {"blank_image", "An image to use when the screen should be blank", "path", ""},
             {"background_color", "The background color of the browser and blank screen (unless there's a blank_image)", "#RRGGBB or name", "white"},
-            {"run_as_root", "Explicitly allow the kiosk to run as the root user", "bool", "false"}
+            {"run_as_root", "Explicitly allow the kiosk to run as the root user", "bool", "false"},
+            {"http_accept_language", "Overrides the default Accept-Language", "language-locale", ""},
+            {"http_user_agent", "Overrides the default User-Agent string", "string", ""}
         });
     parser.addOptions(options);
     parser.process(app);
@@ -90,4 +92,6 @@ KioskSettings::KioskSettings(const QCoreApplication &app)
         zoomFactor = 5.0;
     blankImage = parser.value("blank_image");
     backgroundColor = QColor(parser.value("background_color"));
+    httpAcceptLanguage = parser.value("http_accept_language");
+    httpUserAgent = parser.value("http_user_agent");
 }

--- a/src/KioskSettings.h
+++ b/src/KioskSettings.h
@@ -46,6 +46,8 @@ struct KioskSettings
 
     QString blankImage;
     QColor backgroundColor;
+    QString httpAcceptLanguage;
+    QString httpUserAgent;
 };
 
 #endif // KIOSKSETTINGS_H

--- a/src/KioskView.cpp
+++ b/src/KioskView.cpp
@@ -2,6 +2,7 @@
 #include <QtGui>
 #include <QtWebEngineCore>
 #include <QApplication>
+#include <QWebEngineProfile>
 #include "KioskView.h"
 
 #include "KioskWindow.h"
@@ -13,6 +14,12 @@ KioskView::KioskView(const KioskSettings *settings, QWidget* parent): QWebEngine
 {
     page()->setZoomFactor(settings_->zoomFactor);
     page()->setBackgroundColor(settings_->backgroundColor);
+    if (!settings_->httpAcceptLanguage.isEmpty()) {
+        page()->profile()->setHttpAcceptLanguage(settings_->httpAcceptLanguage);
+    }
+    if (!settings_->httpUserAgent.isEmpty()) {
+        page()->profile()->setHttpUserAgent(settings_->httpUserAgent);
+    }
 
     setFocusPolicy(Qt::StrongFocus);
     setContextMenuPolicy(Qt::PreventContextMenu);


### PR DESCRIPTION
Adds ability to override the Accept Language string (default being "en-US") + the UserAgent string with whatever you want.
If not set, QT browser defaults are kept instead.